### PR TITLE
Fix 'Next' and 'Back' links

### DIFF
--- a/01.inception.html
+++ b/01.inception.html
@@ -168,6 +168,6 @@ Hello, Maarten Billemont
 </section>
 
 <aside class="nav">
-    <h1><a href="commands.html">Next up: Commands And Arguments</a></h1>
+    <h1><a href="02.commands.html">Next up: Commands And Arguments</a></h1>
     <h2><a href="index.html">Back track: Cover</a></h1>
 </aside>

--- a/02.commands.html
+++ b/02.commands.html
@@ -838,6 +838,6 @@ Hello world!</samp></pre>
 </section>
 
 <aside class="nav">
-    <h1><a href="variables.html">Next up: Variables And Expansions</a></h1>
-    <h2><a href="inception.html">Back track: What is bash, and where does it live?</a></h1>
+    <h1><a href="03.variables.html">Next up: Variables And Expansions</a></h1>
+    <h2><a href="01.inception.html">Back track: What is bash, and where does it live?</a></h1>
 </aside>


### PR DESCRIPTION
These links were broken when they were missing the 01 and 02. 
