### PR TITLE
"fork me" now refers to guide.bash.academy repo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,4 +24,4 @@
     {% endif %}
 </footer>
 
-<a href="https://github.com/lhunath/bash.academy" class="fork"><img src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>
+<a href="https://github.com/lhunath/guide.bash.academy" class="fork"><img src="https://camo.githubusercontent.com/52760788cde945287fbb584134c4cbc2bc36f904/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"></a>


### PR DESCRIPTION
the "Fork me on GitHub" link was referring to bash.academy repo instead of guide.bash.academy.
now it redirects to this repo.

(I did this thinking that it is supposed to link to this repository. If this is not the case, I am sorry for disturbing)