### PR TITLE
relative script references break

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,6 @@
     <link rel="stylesheet" type="text/css" href="/css/responsive.css">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
-    <script src="js/vendor/modernizr-2.6.2.min.js"></script>
-    <script src="js/vendor/prefixfree.min.js"></script>
+    <script src="/js/vendor/modernizr-2.6.2.min.js"></script>
+    <script src="/js/vendor/prefixfree.min.js"></script>
 </head>


### PR DESCRIPTION
These resolve to http://guide.bash.academy/expansions/js/vendor/prefixfree.min.js (and 404) when on a page like http://guide.bash.academy/expansions/, so this should fix them.

http://guide.bash.academy/css/normalize.min.css and http://guide.bash.academy/css/responsive.css also 404 currently, but I'm not sure how to fix those.