### PR TITLE
Make images responsive

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -656,6 +656,7 @@ section img[alt] {
     display: block;
     margin: 1em auto;
     padding: 1em;
+    width: 100%;
 }
 section img[alt]:hover {
     background-color: #EEE;


### PR DESCRIPTION
Images are currently not responsive. Found out splitting my screen in two to have the tutorial in half and the editor in the other half. While the text adapts to the new screen size, the non-responsive images make for an horizontal scrolling. 

ps: thanks for the amazing tutorial!