### PR TITLE
Orientation mobile fix

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,12 +3,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-    <meta name="viewport" content="width=device-width">
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
     <link rel="stylesheet" type="text/css" href="/css/normalize.min.css">
     <link rel="stylesheet" type="text/css" href="/css/main.css#1">
     <link rel="stylesheet" type="text/css" href="/css/responsive.css">
+    <link rel="stylesheet" type="text/css" href="/css/lock_screen.css">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 
     <script src="js/vendor/modernizr-2.6.2.min.js"></script>

--- a/css/lock_screen.css
+++ b/css/lock_screen.css
@@ -1,0 +1,9 @@
+@media {orientation: portrait} {
+	section {
+		-webkit-transform: rotate(-90deg);
+		-moz-transform: rotate(-90deg);
+		-o-transform: rotate(-90deg);
+		-ms-transform: rotate(-90deg);
+		transform: rotate(-90deg);
+	}
+}


### PR DESCRIPTION
So, I took a look at the website on my phone, and it didn't look very appealing on mobile in portrait mode (probably because the banner at the top of each chapter is so large and the paragraphs are made for reading on a wider screen). 
So, I *sort of* fixed it, but I haven't tested it because I don't know what your environment is like, and I don't want to risk wasting time on my end testing something on an environment that is completely different. I made 2 simple changes: Firstly, I thought that maybe it would be easier to fix the scale of the screen and not let the user scale in and out so that they don't accidentally click the menu button in the left hand corner (I did that many times). Secondly, I noticed that the pages all seemed to render better horizontally, so I found a quick-fix solution [here](https://gist.github.com/visnup/2605440) using CSS that would fix the page horizontally. 
To reiterate, I didn't test these because I don't know what your environment is like, and I would rather not waste time testing something that isn't on the same environment. If you could test these out and possibly implement them into the webpage or find a better solution, that would be fantastic.

TLDR; I made changes, didn't test them, and would like you to take a look :)