### PR TITLE
Small typo fix in Parameter Expansion section

### DIFF
--- a/expansions.html
+++ b/expansions.html
@@ -507,7 +507,7 @@ https://guide.bash.academy/variables.jpg</pre>
             <th>
 <code class="syntax"><strong>${</strong><var>parameter</var><strong>:</strong><var>start</var>[<strong>:</strong><var>length</var>]<strong>}</strong></code>
             </th>
-            <td><kbd>"${url:<mark>7</mark>}"</kbd></td>
+            <td><kbd>"${url:<mark>8</mark>}"</kbd></td>
             <td>
 <pre>https://<mark>guide.bash.academy/variables.html</mark>
     ↓


### PR DESCRIPTION
Thank you for all the time that's been dedicated to Bash Academy. It's an absolutely amazing resource.

I noticed a small typo in one of the parameter expansion operator examples. `"${url:7}"` should actually be `"${url:8}"` if the expected output is "guide.bash.academy/variables.html" rather than "/guide.bash.academy/variables.html".