### PR TITLE
Fixed typo in site description.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: The Bash Guide
 email: lhunath@lyndir.com
 description: >
-  A complete guide for newcomers and advanced users to correct usage and deep understanding of the bash shell language.
+  A complete guide for newcomers and advanced users to correct usage and deepen understanding of the bash shell language.
 baseurl: ""
 url: "https://guide.bash.academy"
 twitter_username: lhunath


### PR DESCRIPTION
In the file "_config.yml", line 5 contains a grammatically incorrect sentence. I have changed the word "deep" to "deepen" to fix this grammar issue.